### PR TITLE
feat(mvn-versions): support multi-module projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,14 +42,6 @@ Your pom.xml file also needs the following sonatype plugin to automatically clos
 
 - `nexus-staging-maven-plugin`
 
-Also, in order to work with this project, your pom.xml file must include a comment next to the version entry.  This is so that this tool can make appropriate changes.
-
-```
-<version>2.0.1-SNAPSHOT</version> <!-- semantic-release-version-line -->
-```
-
-<span style="font-size:larger;">[See this example project for a sample pom.xml](https://github.com/evansiroky/maven-semantic-release-example/blob/master/pom.xml).</span>
-
 ### Step 3: Create a maven-settings.xml file
 
 You can copy paste [this file](https://github.com/evansiroky/maven-semantic-release-example/blob/master/maven-settings.xml) into your repository.  The file must be called `maven-settings.xml` and must exist in the root directory of your project.

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -89,33 +89,17 @@ function exec () {
  * Change the pom.xml file, commit the change and then push it to the repo
  */
 async function commitVersionInPomXml (versionStr) {
-  let pomLines
-  try {
-    pomLines = (await fs.readFile('./pom.xml', 'utf8')).split('\n')
-  } catch (e) {
-    debug(e)
-    throw new Error('Error reading pom.xml')
-  }
-
-  // manually iterate through lines and make edits to
-  // preserve formatting and comments of file
-  for (let i = 0; i < pomLines.length; i++) {
-    const line = pomLines[i]
-    if (line.indexOf('<!-- semantic-release-version-line -->') > -1) {
-      // edit version field
-      pomLines[i] = line.replace(/<version>(.*)<\/version>/, `<version>${versionStr}</version>`)
-      break
-    }
-  }
-
-  await fs.writeFile('./pom.xml', pomLines.join('\n'))
+  await exec(
+    'mvn',
+    ['versions:set', 'versions:commit', `-DnewVersion=${versionStr}`]
+  )
 
   const commitMessage = versionStr.indexOf('SNAPSHOT') > -1
     ? `Prepare next development iteration ${versionStr} [ci skip]`
     : `${versionStr} [ci skip]`
 
   debug('adding pom.xml to a commmit')
-  await exec('git', ['add', 'pom.xml'])
+  await exec('git', ['add', '**/pom.xml'])
 
   debug('committing changes')
   await exec('git', ['commit', '-m', commitMessage])

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -1,6 +1,5 @@
 const debug = require('debug')('maven-semantic-release:publish')
 const execa = require('execa')
-const fs = require('fs-extra')
 const semanticGithub = require('@semantic-release/github')
 const {gitHead: getGitHead} = require('semantic-release/lib/git')
 


### PR DESCRIPTION
- Add support for multi-module projects without the need to crawl the project directories.
- Leverage the [versions-maven-plugin](https://www.mojohaus.org/versions-maven-plugin/) to update versions in all project
  - This does not require an entry in the project pom.
poms.
- Remove the need for `pom.xml` comment to target version for change.