### PR TITLE
fix: explicitly ignore generated poms rather than immediately commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-node_modules
+/.idea/
+/node_modules/

--- a/lib/maven.js
+++ b/lib/maven.js
@@ -7,7 +7,7 @@ async function updateVersionInPomXml (logger, versionStr) {
   logger.log(`Updating pom.xml to version ${versionStr}`)
   await exec(
     'mvn',
-    ['versions:set', 'versions:commit', `-DnewVersion=${versionStr}`]
+    ['versions:set', '-DgenerateBackupPoms=false', `-DnewVersion=${versionStr}`]
   )
 }
 


### PR DESCRIPTION
Reading more on the maven-versions-plugin documentation. For myself, the only reason I was using 'commit' was to clean up the generated pomBackup files.