### PR TITLE
Run mvn package when skip maven deploy flag is set

### DIFF
--- a/lib/definitions/errors.js
+++ b/lib/definitions/errors.js
@@ -9,7 +9,7 @@ Please check the logs on the CI server to see what happened.`
   }),
   EMAVENPACKAGE: () => ({
     message: 'Packaging with maven failed.',
-    details: `Maven failed package the project for an unknown reason.
+    details: `Maven failed to package the project for an unknown reason.
 
 Please check the logs on the CI server to see what happened.`
   }),

--- a/lib/definitions/errors.js
+++ b/lib/definitions/errors.js
@@ -7,6 +7,12 @@ module.exports = {
 
 Please check the logs on the CI server to see what happened.`
   }),
+  EMAVENPACKAGE: () => ({
+    message: 'Packaging with maven failed.',
+    details: `Maven failed package the project for an unknown reason.
+
+Please check the logs on the CI server to see what happened.`
+  }),
   ENOMAVENSETTINGS: () => ({
     message: 'Missing the `maven-settings.xml` file.',
     details: `The \`maven-settings.xml\` file could not be found in this repository.

--- a/lib/maven.js
+++ b/lib/maven.js
@@ -28,7 +28,26 @@ async function deploy (logger, nextRelease) {
   }
 }
 
+/**
+ * Run the maven command to package the project. `package` is a reserved word,
+ * so that's why the function is named this way.
+ */
+async function mvnPackage (logger) {
+  logger.log('Packaging with maven')
+  try {
+    await exec(
+      'mvn',
+      ['package', '-DskipTests']
+    )
+  } catch (e) {
+    logger.error('failed to package with maven')
+    logger.error(e)
+    throw getError('EMAVENPACKAGE')
+  }
+}
+
 module.exports = {
-  updateVersionInPomXml,
-  deploy
+  deploy,
+  mvnPackage,
+  updateVersionInPomXml
 }

--- a/lib/maven.js
+++ b/lib/maven.js
@@ -12,7 +12,9 @@ async function updateVersionInPomXml (logger, versionStr) {
 }
 
 /**
- * Run the maven command to deploy the project
+ * Run the maven command to deploy the project. The tests are skipped because it
+ * is assumed that they have already successfully been ran in the script part of
+ * the CI build.
  */
 async function deploy (logger, nextRelease) {
   logger.log('Deploying version %s with maven', nextRelease.version)
@@ -30,7 +32,9 @@ async function deploy (logger, nextRelease) {
 
 /**
  * Run the maven command to package the project. `package` is a reserved word,
- * so that's why the function is named this way.
+ * so that's why the function is named this way. The tests are skipped because
+ * it is assumed that they have already successfully been ran in the script part
+ * of the CI build.
  */
 async function mvnPackage (logger) {
   logger.log('Packaging with maven')

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -1,5 +1,5 @@
 const {configureGit, mergeMasterIntoDev, saveChangesToPomXml} = require('./git')
-const {updateVersionInPomXml, deploy} = require('./maven')
+const {deploy, mvnPackage, updateVersionInPomXml} = require('./maven')
 const {printVersion} = require('./util')
 
 /**
@@ -12,7 +12,16 @@ module.exports = async function publish (pluginConfig, context) {
   printVersion(logger)
 
   if (!options.skipMavenDeploy) {
+    // deploy the project to maven-central
     await deploy(logger, nextRelease)
+  } else if (options.useConveyalWorkflow) {
+    // Although this library is being ran with instructions to skip the
+    // deployment to maven central, the package command is still needed in the
+    // Conveyal workflow. This is because sometimes the jar that is generated
+    // from the package command when the project is in the release state commit
+    // is needed by other tasks in Travis.
+    // See https://github.com/conveyal/datatools-server/issues/181
+    await mvnPackage(logger)
   }
 
   // special logic to do some extra Conveyal-specific tasks


### PR DESCRIPTION
At Conveyal, we encountered some issues that require the `mvn package` command (or some kind of maven command that ends up producing jar files) to be executed on the release commit. This PR enables that functionality.

See https://github.com/conveyal/datatools-server/issues/181