### PR TITLE
Bump semantic-release version in docs from 15 -> 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Automated release management for maven projects
 
 ## About
 
-maven-semantic-release is a plugin for [semantic-release](https://github.com/semantic-release/semantic-release) v15.  This project will deploy a maven project to maven central instead of deploying a node.js project to npm.  This tool is intended to be used on github projects that use a Travis-CI server.
+maven-semantic-release is a plugin for [semantic-release](https://github.com/semantic-release/semantic-release) v17.  This project will deploy a maven project to maven central instead of deploying a node.js project to npm.  This tool is intended to be used on github projects that use a Travis-CI server.
 
 The workflow this assumes is that your project will use [Angular-style commit messages](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#type) (theoretically you could override this and use a different style) and only merge to master when you want to create a new release.  When a new release is generated, it will automatically be deployed to maven central.
 


### PR DESCRIPTION
This is a dummy commit/PR with breaking change to account for the dependabot version bump, which may
not break anything internally, but could have breaking changes for users of thiis library.

BREAKING CHANGE: d00f93b34e7a317cad4cfc0c262d25c784248892 contains breaking change (bumps
semantic-release from 15 -> 17)